### PR TITLE
Windows向けクロスコンパイルを簡単化するための変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,21 +40,19 @@ Notes for AIX users:
 	* GNU-style long options are not supported, but are accessible
 	  via configuration file
 
+
 Windows build instructions on Ubuntu 16.04LTS:
+
 	sudo apt-get install gcc-mingw-w64
 	cd cpuminer/depend
 	sh depend.sh
 	cd cpuminer
 	./autogen.sh
 	LDFLAGS="-L depend/curl-7.38.0-devel-mingw64/lib64 -static" LIBCURL="-lcurldll" \
-		CFLAGS="-O3 -msse4.1 -funroll-loops -fomit-frame-pointer" \
-		./configure --host=x86_64-w64-mingw32 --with-libcurl=depend/curl-7.38.0-devel-mingw64
+	CFLAGS="-O3 -msse4.1 -funroll-loops -fomit-frame-pointer" \
+	./configure --host=x86_64-w64-mingw32 --with-libcurl=depend/curl-7.38.0-devel-mingw64
 	make
-	#For Win32
-	#LDFLAGS="-L depend/curl-7.38.0-devel-mingw32/lib -static" LIBCURL="-lcurldll" \
-	#	CFLAGS="-O3 -msse4.1 -funroll-loops -fomit-frame-pointer" \
-	#	./configure --host=i686-w64-mingw32 --with-libcurl=depend/curl-7.38.0-devel-mingw32
-	#make
+
 
 Architecture-specific notes:
 

--- a/README.md
+++ b/README.md
@@ -33,30 +33,28 @@ Basic *nix build instructions:
     ./configure CFLAGS="-O3"
     make
 	
-
+	
 Notes for AIX users:
 
 	* To build a 64-bit binary, export OBJECT_MODE=64
 	* GNU-style long options are not supported, but are accessible
 	  via configuration file
 
-Basic Windows build instructions, using MinGW:
-
-	Install MinGW and the MSYS Developer Tool Kit (http://www.mingw.org/)
-	* Make sure you have mstcpip.h in MinGW\include
-
-	If using MinGW-w64, install pthreads-w64
-	
-	Install libcurl devel (http://curl.haxx.se/download.html)
-	
-		* Make sure you have libcurl.m4 in MinGW\share\aclocal
-		* Make sure you have curl-config in MinGW\bin
-
-	In the MSYS shell, run:
-
-    ./autogen.sh	# only needed if building from git repo
-    LIBCURL="-lcurldll" ./configure CFLAGS="-O3"
-    make
+Windows build instructions on Ubuntu 16.04LTS:
+	sudo apt-get install gcc-mingw-w64
+	cd cpuminer/depend
+	sh depend.sh
+	cd cpuminer
+	./autogen.sh
+	LDFLAGS="-L depend/curl-7.38.0-devel-mingw64/lib64 -static" LIBCURL="-lcurldll" \
+		CFLAGS="-O3 -msse4.1 -funroll-loops -fomit-frame-pointer" \
+		./configure --host=x86_64-w64-mingw32 --with-libcurl=depend/curl-7.38.0-devel-mingw64
+	make
+	#For Win32
+	#LDFLAGS="-L depend/curl-7.38.0-devel-mingw32/lib -static" LIBCURL="-lcurldll" \
+	#	CFLAGS="-O3 -msse4.1 -funroll-loops -fomit-frame-pointer" \
+	#	./configure --host=i686-w64-mingw32 --with-libcurl=depend/curl-7.38.0-devel-mingw32
+	#make
 
 Architecture-specific notes:
 

--- a/depend/depend.sh
+++ b/depend/depend.sh
@@ -1,0 +1,12 @@
+echo 'download libcurl64'
+wget https://curl.haxx.se/gknw.net/rm/7.38.0/dist-w64/curl-7.38.0-devel-mingw64.zip
+unzip curl-7.38.0-devel-mingw64.zip
+echo '#/bin/sh'              >  curl-7.38.0-devel-mingw64/bin/curl-config
+echo 'echo "libcurl 7.38.0"' >> curl-7.38.0-devel-mingw64/bin/curl-config
+chmod 755 curl-7.38.0-devel-mingw64/bin/curl-config
+
+echo 'download libcurl32'
+wget https://curl.haxx.se/gknw.net/rm/7.38.0/dist-w32/curl-7.38.0-devel-mingw32.zip
+echo '#/bin/sh'               > curl-7.38.0-devel-mingw32/bin/curl-config
+echo 'echo "libcurl 7.38.0"' >> curl-7.38.0-devel-mingw32/bin/curl-config
+chmod 755 curl-7.38.0-devel-mingw32/bin/curl-config

--- a/depend/depend.sh
+++ b/depend/depend.sh
@@ -7,6 +7,7 @@ chmod 755 curl-7.38.0-devel-mingw64/bin/curl-config
 
 echo 'download libcurl32'
 wget https://curl.haxx.se/gknw.net/rm/7.38.0/dist-w32/curl-7.38.0-devel-mingw32.zip
+unzip curl-7.38.0-devel-mingw32.zip
 echo '#/bin/sh'               > curl-7.38.0-devel-mingw32/bin/curl-config
 echo 'echo "libcurl 7.38.0"' >> curl-7.38.0-devel-mingw32/bin/curl-config
 chmod 755 curl-7.38.0-devel-mingw32/bin/curl-config

--- a/yescrypt-platform.c
+++ b/yescrypt-platform.c
@@ -18,7 +18,7 @@
  * SUCH DAMAGE.
  */
 
-#include <sys/mman.h>
+//#include <sys/mman.h>
 #include "yescrypt.h"
 #define HUGEPAGE_THRESHOLD		(12 * 1024 * 1024)
 


### PR DESCRIPTION
Windows環境向けにクロスコンパイルをUbuntuから簡単に行えるように変更を加えました．Windows7とWindows10で動作確認できました．
変更点は，必要な依存ライブラリだけを取得するスクリプトを追加し不必要な「sys/mman.h」を除去した点，バイナリをReleasesに追加した点です．
ご検討お願い致します．