### PR TITLE
fix aclocal missing dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ MAINTAINER	Guillaume J. Charmes <guillaume@charmes.net>
 
 RUN		apt-get update -qq
 
+RUN		apt-get install -qqy autotools-dev
 RUN		apt-get install -qqy automake
 RUN		apt-get install -qqy libcurl4-openssl-dev
 RUN		apt-get install -qqy git

--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ Dependencies:
 
 Install Build Dependencies on Debian, Ubuntu and other APT-based distros:
 
-    sudo apt-get install build-essential libcurl4-openssl-dev
+    sudo apt-get install build-essential libcurl4-openssl-dev autotools-dev automake
 
 Install Build Dependencies on Fedora, RHEL, CentOS and other yum-based distros:
 
-    sudo yum install gcc make curl-devel
+    sudo yum install gcc make curl-devel automake
 
 Install Build Dependencies on OpenSUSE and other ZYpp-based distros:
 
-    sudo zypper in gcc make libcurl-devel
+    sudo zypper in gcc make libcurl-devel automake
 
 Basic *nix build instructions:
 


### PR DESCRIPTION
On some systems, an `aclocal: Command not found make` error may be encountered, and this commit adds this dependency requirement to the `README.md` and `Dockerfile` files.